### PR TITLE
Can upgrades to upgrade and install script

### DIFF
--- a/install.js
+++ b/install.js
@@ -16,7 +16,13 @@ var optimist = require('optimist');
 var util = require('util');
 var _ = require('underscore');
 var ncp = require('ncp').ncp;
-var versionFile = JSON.parse(fs.readFileSync('version.json'), {encoding: 'utf8'});
+
+try{
+  var versionFile = JSON.parse(fs.readFileSync('version.json'), {encoding: 'utf8'});
+}
+catch (err) {
+  versionFile = {}
+}
 
 // set overrides from command line arguments
 prompt.override = optimist.argv;
@@ -273,17 +279,28 @@ var steps = [
                 return callback(error);
               }
 
-              var packageFile = JSON.parse(data);
-              versionFile.adapt_framework = 'v' + packageFile.version;
-              fs.writeFile('version.json', JSON.stringify(versionFile, null, 4), function(err) {
-                if(err) {
-                  console.error('ERROR: ' + err);
-                  return next(err);
+              var framework_package_file = JSON.parse(data);
+              fs.readFile(path.resolve(__dirname,'package.json'), function(error, data) {
+                if (error) {
+                  console.error('ERROR: ' + error);
+                  return callback(error);
                 }
 
-                console.log("Version file updated\n");
-                return next();
+                var at_package_file = JSON.parse(data);
 
+                versionFile.adapt_framework = 'v' + framework_package_file.version;
+                versionFile.adapt_authoring = 'v' + at_package_file.version;
+
+                fs.writeFile('version.json', JSON.stringify(versionFile, null, 4), function(err) {
+                  if(err) {
+                    console.error('ERROR: ' + err);
+                    return next(err);
+                  }
+
+                  console.log("Version file updated\n");
+                  return next();
+
+                });
               });
             });
           });

--- a/lib/frameworkhelper.js
+++ b/lib/frameworkhelper.js
@@ -1,10 +1,10 @@
 // LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
 var path = require('path'),
-    fs = require('fs'),
-    util = require('util'),
-    rimraf = require('rimraf'),
-    exec = require('child_process').exec,
-    serverRoot = require('./configuration').serverRoot;
+  fs = require('fs'),
+  util = require('util'),
+  rimraf = require('rimraf'),
+  exec = require('child_process').exec,
+  serverRoot = require('./configuration').serverRoot;
 
 // errors
 function FrameworkError (message) {
@@ -15,15 +15,13 @@ function FrameworkError (message) {
 util.inherits(FrameworkError, Error);
 
 
-var FRAMEWORK_DIR = 'adapt_framework',
-  DEFAULT_BRANCH = 'master',
-  GIT_FRAMEWORK_CLONE_URL = 'https://github.com/adaptlearning/adapt_framework.git';
-  
+var FRAMEWORK_DIR = 'adapt_framework';
+
 function flog(msg) {
   console.log(' ' + msg);
 }
 
-function cloneFramework (next) {
+function cloneFramework (next, frameworkRepository, frameworkRevision) {
   fs.exists (path.join(serverRoot, FRAMEWORK_DIR), function (exists) {
     if (exists) {
       // don't bother installing again
@@ -32,42 +30,34 @@ function cloneFramework (next) {
     }
 
     console.log('The Adapt Framework was not found. It will now be installed...');
-    var child = exec('git clone ' + GIT_FRAMEWORK_CLONE_URL, {
+    var child = exec('git clone ' + frameworkRepository, {
       stdio: [0, 'pipe', 'pipe']
     });
-    
+
     child.stdout.on('data', flog);
     child.stderr.on('data', flog);
-    
+
     child.on('exit', function (error, stdout, stderr) {
       if (error) {
         console.log('ERROR: ' + error);
         return next(error);
       }
-      
+
       console.log("Clone from GitHub was successful.");
-      return installFramework(next);
+      return installFramework(next, frameworkRevision);
     });
   });
 };
 
-function installFramework (next) {
-  var frameworkVersion = DEFAULT_BRANCH;
+function installFramework (next, frameworkRevision) {
 
-  try {
-    var versionFile = JSON.parse(fs.readFileSync('version.json'), {encoding: 'utf8'});
-    frameworkVersion = versionFile.adapt_framework;
-  } catch (e) {
-    console.log('Warning: Failed to determine compatible Adapt Framework version from version.json, so using ' + DEFAULT_BRANCH);
-  }
-  
   console.log('Running \'npm install\' for the Adapt Framework...');
-  
-  var child = exec('git checkout --quiet ' + frameworkVersion + ' && npm install', {
-    cwd: FRAMEWORK_DIR, 
+
+  var child = exec('git checkout --quiet ' + frameworkRevision + ' && npm install', {
+    cwd: FRAMEWORK_DIR,
     stdio: [0, 'pipe', 'pipe']
   });
-    
+
   child.stdout.on('data', flog);
   child.stderr.on('data', flog);
 
@@ -76,15 +66,15 @@ function installFramework (next) {
       console.log('ERROR: ', error);
       return next(error);
     }
-    
+
     console.log("Completed installing NodeJS modules.\n");
-    
+
     // Remove the default course.
     rimraf(path.join(serverRoot, FRAMEWORK_DIR, 'src', 'course'), function(err) {
       if (err) {
         console.log('ERROR:', error);
       }
-      
+
       return next();
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-origin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "GPL-3.0",
   "description": "Adapt framework authoring tool core application",
   "keywords": [

--- a/upgrade.js
+++ b/upgrade.js
@@ -27,19 +27,28 @@ var installedFrameworkVersion = '';
 var latestFrameworkTag = null;
 var shouldUpdateBuilder = false;
 var shouldUpdateFramework = false;
-var versionFile = JSON.parse(fs.readFileSync('version.json'), {encoding: 'utf8'});
 var configFile = JSON.parse(fs.readFileSync(path.join('conf','config.json')), {encoding: 'utf8'});
 var upgradeOptions = {
   automatic: true
 };
+
+try{
+  var versionFile = JSON.parse(fs.readFileSync('version.json'), {encoding: 'utf8'});
+}
+catch (err) {
+  versionFile = {}
+}
 
 var steps = [
   function(callback) {
 
     console.log('Checking versions');
 
-    if (versionFile) {
+    if (typeof versionFile.adapt_authoring !== 'undefined') {
       installedBuilderVersion = versionFile.adapt_authoring;
+    }
+
+    if (typeof versionFile.adapt_framework !== 'undefined') {
       installedFrameworkVersion = versionFile.adapt_framework;
     }
 
@@ -155,7 +164,7 @@ var steps = [
           return callback(err);
         }
 
-        versionFile.adapt_authoring = data.version;
+        versionFile.adapt_authoring = 'v' + data.version;
         callback();
 
       });
@@ -175,7 +184,7 @@ var steps = [
           return callback(err);
         }
 
-        versionFile.adapt_framework = data.version;
+        versionFile.adapt_framework = 'v' + data.version;
         callback();
 
       });
@@ -277,7 +286,7 @@ app.on('serverStarted', function () {
             frameworkGitTag: {
               type: 'string',
               required: true,
-              description: 'Framework git git revision (enter branch name or tag as tags/[tagname])'
+              description: 'Framework git revision (enter branch name or tag as tags/[tagname])'
             }
           }
         };

--- a/version.json
+++ b/version.json
@@ -1,4 +1,0 @@
-{
-    "adapt_authoring": "v0.2.2",
-    "adapt_framework": "v2.0.7"
-}


### PR DESCRIPTION
Install and upgrade script can now use any git repository framework and AT can continue to be updated automatically if they use the adapt community repo's or be updated to a specific git tag or branch.

Error's on the install and upgrade scripts are now passed to stderr, and they return none 0 error codes much less often when erroring.

By default, the latest framework version is now installed.

Version.json is not tracked and has been removed from VCS it is now generated when the install script is run, from the version in the package.json

To use it on install:
1. Pull this branch to an install.
1. `node install`
1. When asked to give your own AT and framework repo.
1. Pass a git branch or tag in the form `tags/[tag]` that you want the framework on or use the default it will get the latest. (what ever you pass is passed to `git checkout`)

To use on upgrade:
1. Enter `n` when asked if you wish to do an automatic upgrade.
2. Enter a git tag or branch for the AT and Framework. (what ever you pass is passed to `git checkout`)

If you chnage the repos in the config file they will be used on your next update.

Fixes:
* https://github.com/adaptlearning/adapt_authoring/issues/1626
* https://github.com/adaptlearning/adapt_authoring/issues/1570

Known Issues:
1. Github api is used to get the latest version tags but without authenticaton it limits your IP to 60 requests an hour this is not a lot when testing and currently the install fails once the 60 request limit is it hit.