### PR TITLE
Fix ability to group themeVariables

### DIFF
--- a/frontend/src/modules/editor/themeEditor/less/editorTheming.less
+++ b/frontend/src/modules/editor/themeEditor/less/editorTheming.less
@@ -62,18 +62,19 @@
   .theme-customiser {
     .form-container-style;
     .form-container {
-      // HACK to hide fieldset titles
       .legend {
         display: none;
       }
       fieldset {
-        margin: 0;
         border: none;
         padding-bottom: 0;
         max-width: none;
         .field {
           padding-left: 0;
         }
+      }
+      fieldset.fieldset-general {
+        margin-top: 0;
       }
     }
   }

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -525,12 +525,12 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
  * @param next
  */
 OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVariables, destinationFolder, next) {
-  var themeAssetsFolder = path.join(destinationFolder, Constants.Folders.Assets);
   var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.ThemeVariables);
-  var SEPARATOR = '-';
-  var props = [];
-  var savedSettings = [];
   var modifiedProperties = "";
+  var props = {};
+  var savedSettings = {};
+  var SEPARATOR = '-';
+  var themeAssetsFolder = path.join(destinationFolder, Constants.Folders.Assets);
   async.series([
     function(seriesCallback) {
       // Flatten the property names to allow two levels
@@ -540,7 +540,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
         if (theme.properties[key].hasOwnProperty('properties')) {
           // There are nested properties to process
           async.eachSeries(_.keys(theme.properties[key].properties), function(childKey, secondInnerCallback) {
-            props.push(key + SEPARATOR + childKey);
+            props[key + SEPARATOR + childKey] = childKey;
             theme.properties[key + SEPARATOR + childKey] = theme.properties[key].properties[childKey];
 
             secondInnerCallback();
@@ -552,8 +552,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
             innerCallback();
           });
         } else {
-          // Push the property as is
-          props.push(key);
+          props[key] = key;
           innerCallback();
         }
       },
@@ -593,7 +592,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
     },
     function(seriesCallback) {
       // Create LESS for properties
-      async.each(props, function(prop, innerCallback) {
+      async.each(Object.keys(props), function(prop, innerCallback) {
         // Check if the user has customised any properties
         if (savedSettings.hasOwnProperty(prop) && theme.properties[prop].default !== savedSettings[prop]) {
           // The user has customised this property
@@ -607,7 +606,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
             savedSettings[prop] = "\"" + assetPathArray.join('/').replace('course/', '') + "\"";
           }
 
-          modifiedProperties += '@' + prop + ' : ' + savedSettings[prop] + ';\n';
+          modifiedProperties += '@' + props[prop] + ' : ' + savedSettings[prop] + ';\n';
         }
         innerCallback();
       }, function(err) {


### PR DESCRIPTION
Should  be able to group themeVariables underneath headings, update outputmanager.js to deal with nested objects and editorTheming.less to show headings.