### PR TITLE
Display error information on plugin upload modal

### DIFF
--- a/frontend/src/core/helpers.js
+++ b/frontend/src/core/helpers.js
@@ -172,12 +172,6 @@ define(function(require){
       return new Handlebars.SafeString(html + '</ul>');
     },
 
-    decodeHTML: function(html) {
-      var el = document.createElement('div');
-      el.innerHTML = html;
-      return el.childNodes.length === 0 ? "" : el.childNodes[0].nodeValue;
-    },
-
     ifHasPermissions: function(permissions, block) {
       var hasPermission = Origin.permissions.hasPermissions(permissions.split(','));
       return hasPermission ? block.fn(this) : block.inverse(this);

--- a/frontend/src/modules/pluginManagement/views/pluginManagementUploadView.js
+++ b/frontend/src/modules/pluginManagement/views/pluginManagementUploadView.js
@@ -61,7 +61,7 @@ define(function(require){
       Origin.Notify.alert({
         type: 'error',
         title: Origin.l10n.t('app.uploadpluginerror'),
-        text: Helpers.decodeHTML(message)
+        text: message
       });
       Origin.router.navigateTo('pluginManagement/upload');
     },

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -813,7 +813,7 @@ function addPackage (plugin, packageInfo, options, cb) {
         if (results && 0 !== results.length) {
           // don't add duplicate
           if (options.strict) {
-            return addCb(new PluginPackageError("Can't add plugin: plugin already exists!"));
+            return addCb(new PluginPackageError(app.polyglot.t('app.versionexists')));
           }
           return addCb(null);
         }
@@ -1058,7 +1058,7 @@ function handleUploadedPlugin (req, res, next) {
 
     var file = files.file;
     if (!file || !file.path) {
-      return next(new PluginPackageError('File upload failed!'));
+      return next(new PluginPackageError(app.polyglot.t('app.fileuploaderror')));
     }
 
     // try unzipping
@@ -1104,17 +1104,19 @@ function handleUploadedPlugin (req, res, next) {
 
           }, function(hasResults) {
             if (!hasResults) {
-              return next(new PluginPackageError('Cannot find expected bower.json file in the plugin root, please check the structure of your zip file and try again.'));
+              return next(app.polyglot.t('app.cannotfindbower'));
             }
 
             if (!packageJson) {
-              return next(new PluginPackageError('Unrecognized plugin - a plugin should have a bower.json file'));
+              return next(app.polyglot.t('app.unrecognisedplugin'));
             }
 
             // extract the plugin type from the package
             var pluginType = extractPluginType(packageJson);
             if (!pluginType) {
-              return next(new PluginPackageError('Unrecognized plugin type for package ' + packageJson.name));
+              return next(new PluginPackageError(app.polyglot.t('app.unrecognisedpluginforpackage', {
+                package: packageJson.name
+              })));
             }
 
             // mark as a locally installed package
@@ -1132,7 +1134,9 @@ function handleUploadedPlugin (req, res, next) {
               }
               // Check if the framework has been defined on the plugin and that it's not compatible
               if (packageInfo.pkgMeta.framework && !semver.satisfies(semver.clean(frameworkVersion), packageInfo.pkgMeta.framework, { includePrerelease: true })) {
-                return next(new PluginPackageError('This plugin is incompatible with version ' + frameworkVersion + ' of the Adapt framework'));
+                return next(new PluginPackageError(app.polyglot.t('app.incompatibleframework', {
+                  framework: frameworkVersion
+                })));
               }
               app.contentmanager.getContentPlugin(pluginType, function (error, contentPlugin) {
                 if (error) {
@@ -1145,10 +1149,9 @@ function handleUploadedPlugin (req, res, next) {
 
                   function sendResponse() {
                     res.statusCode = 200;
-                    return res.json({ 
-                      success: true, 
-                      pluginType: pluginType, 
-                      message: 'successfully added new plugin' 
+                    return res.json({
+                      success: true,
+                      pluginType: pluginType
                     });
                   }
 

--- a/routes/lang/en-application.json
+++ b/routes/lang/en-application.json
@@ -410,5 +410,11 @@
   "app.searchByMail": "Search by email",
   "app.maxfileuploadsize": "Maximum upload file size: %{size}.",
   "app.uploadsizeerror": "File size limit exceeded. Expected no more than %{max}, received %{size}.",
+  "app.fileuploaderror": "File upload failed.",
+  "app.cannotfindbower": "Cannot find expected bower.json file in the plugin root, please check the structure of your zip file and try again.",
+  "app.unrecognisedplugin": "Unrecognized plugin - a plugin should have a bower.json file.",
+  "app.unrecognisedpluginforpackage": "Unrecognized plugin type for package %{package}.",
+  "app.incompatibleframework": "This plugin is incompatible with version %{framework} of the Adapt framework.",
+  "app.versionexists": "You already have this version of the plugin installed.",
   "app.unknownuser": "Unknown User"
 }

--- a/routes/lang/en-application.json
+++ b/routes/lang/en-application.json
@@ -413,7 +413,7 @@
   "app.fileuploaderror": "File upload failed.",
   "app.cannotfindbower": "Cannot find expected bower.json file in the plugin root, please check the structure of your zip file and try again.",
   "app.unrecognisedplugin": "Unrecognized plugin - a plugin should have a bower.json file.",
-  "app.unrecognisedpluginforpackage": "Unrecognized plugin type for package %{package}.",
+  "app.unrecognisedpluginforpackage": "Unrecognised plugin type for package %{package}.",
   "app.incompatibleframework": "This plugin is incompatible with version %{framework} of the Adapt framework.",
   "app.versionexists": "You already have this version of the plugin installed.",
   "app.unknownuser": "Unknown User"

--- a/routes/lang/en-application.json
+++ b/routes/lang/en-application.json
@@ -412,7 +412,7 @@
   "app.uploadsizeerror": "File size limit exceeded. Expected no more than %{max}, received %{size}.",
   "app.fileuploaderror": "File upload failed.",
   "app.cannotfindbower": "Cannot find expected bower.json file in the plugin root, please check the structure of your zip file and try again.",
-  "app.unrecognisedplugin": "Unrecognized plugin - a plugin should have a bower.json file.",
+  "app.unrecognisedplugin": "Unrecognised plugin - a plugin should have a bower.json file.",
   "app.unrecognisedpluginforpackage": "Unrecognised plugin type for package %{package}.",
   "app.incompatibleframework": "This plugin is incompatible with version %{framework} of the Adapt framework.",
   "app.versionexists": "You already have this version of the plugin installed.",


### PR DESCRIPTION
The back end was already reporting detailed error messages, but due to a bug on the front end, these were never displayed.

- Removed unnecessary decodeHTML method from front end so that messages can be displayed

- Moved existing error messages to language file so that they can be translated now that they will appear in the UI