### PR TITLE
Clear build folder on export and publish

### DIFF
--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -94,6 +94,7 @@ function publishCourse(courseId, mode, request, response, next) {
         }
 
         if (mode === Constants.Modes.Export || mode === Constants.Modes.Publish) {
+          fs.emptyDirSync(BUILD_FOLDER);
           isRebuildRequired = true;
           return callback(null);
         }

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -29,11 +29,11 @@ function publishCourse(courseId, mode, request, response, next) {
   let resultObject = {};
 
   // shorthand directories
-  let FRAMEWORK_ROOT_FOLDER = path.join(configuration.tempDir, configuration.getConfig('masterTenantID'), Constants.Folders.Framework);
-  let SRC_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.Source);
-  let COURSES_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.AllCourses);
-  let COURSE_FOLDER = path.join(COURSES_FOLDER, tenantId, courseId);
-  let BUILD_FOLDER = path.join(COURSE_FOLDER, Constants.Folders.Build);
+  const FRAMEWORK_ROOT_FOLDER = path.join(configuration.tempDir, configuration.getConfig('masterTenantID'), Constants.Folders.Framework);
+  const SRC_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.Source);
+  const COURSES_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.AllCourses);
+  const COURSE_FOLDER = path.join(COURSES_FOLDER, tenantId, courseId);
+  const BUILD_FOLDER = path.join(COURSE_FOLDER, Constants.Folders.Build);
 
   let customPluginName = user._id;
 

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -15,26 +15,27 @@ const origin = require('../../../');
 const usermanager = require('../../../lib/usermanager');
 
 function publishCourse(courseId, mode, request, response, next) {
-  var app = origin();
-  var self = this;
-  var user = usermanager.getCurrentUser();
-  var tenantId = user.tenant._id;
-  var outputJson = {};
-  var isRebuildRequired = false;
-  var themeName;
-  var menuName;
-  var frameworkVersion;
+  let app = origin();
+  let self = this;
+  let user = usermanager.getCurrentUser();
+  let tenantId = user.tenant._id;
+  let outputJson = {};
+  let isRebuildRequired = false;
+  let themeName;
+  let menuName;
+  let frameworkVersion;
+  let isForceRebuild;
 
-  var resultObject = {};
+  let resultObject = {};
 
   // shorthand directories
-  var FRAMEWORK_ROOT_FOLDER = path.join(configuration.tempDir, configuration.getConfig('masterTenantID'), Constants.Folders.Framework);
-  var SRC_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.Source);
-  var COURSES_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.AllCourses);
-  var COURSE_FOLDER = path.join(COURSES_FOLDER, tenantId, courseId);
-  var BUILD_FOLDER = path.join(COURSE_FOLDER, Constants.Folders.Build);
+  let FRAMEWORK_ROOT_FOLDER = path.join(configuration.tempDir, configuration.getConfig('masterTenantID'), Constants.Folders.Framework);
+  let SRC_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.Source);
+  let COURSES_FOLDER = path.join(FRAMEWORK_ROOT_FOLDER, Constants.Folders.AllCourses);
+  let COURSE_FOLDER = path.join(COURSES_FOLDER, tenantId, courseId);
+  let BUILD_FOLDER = path.join(COURSE_FOLDER, Constants.Folders.Build);
 
-  var customPluginName = user._id;
+  let customPluginName = user._id;
 
   const getGruntFatalError = stdout => {
     const indexStart = stdout.indexOf('\nFatal error: ');
@@ -94,15 +95,20 @@ function publishCourse(courseId, mode, request, response, next) {
         }
 
         if (mode === Constants.Modes.Export || mode === Constants.Modes.Publish) {
-          fs.emptyDirSync(BUILD_FOLDER);
           isRebuildRequired = true;
           return callback(null);
         }
 
-        const isForceRebuld = (request) ? request.query.force === 'true' : false;
-        isRebuildRequired = exists || isForceRebuld;
+        isForceRebuild = (request) ? request.query.force === 'true' : false;
+        isRebuildRequired = exists || isForceRebuild;
         callback(null);
       });
+    },
+    function(callback) {
+      if (mode === Constants.Modes.Export || mode === Constants.Modes.Publish || isForceRebuild) {
+        fs.emptyDirSync(BUILD_FOLDER);
+      }
+      callback(null);
     },
     function(callback) {
       var temporaryMenuFolder = path.join(SRC_FOLDER, Constants.Folders.Menu, customPluginName);


### PR DESCRIPTION
In the authoring tool the build folder is not being emptied between builds.

If a course with themeA is built, then the build folder will contain assets for themeA.

If the course is switched to use themeB then any assets with the same name will overwrite those from themeA, but any additional assets from themeA will remain in the build.

There isn't a noticeable issue in the courses themselves from a user perspective, but this can lead to very large publish files.

This change empties the build folder when it's contents are going to be regenerated, ensuring it only contains assets for the currently selected theme.

